### PR TITLE
Fix dependencies

### DIFF
--- a/cybertensor/__init__.py
+++ b/cybertensor/__init__.py
@@ -30,7 +30,7 @@ from rich.traceback import install
 nest_asyncio.apply()
 
 # Cybertensor code and protocol version.
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 version_split = __version__.split(".")
 __version_as_int__ = (
     (100 * int(version_split[0]))

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -37,5 +37,4 @@ cosmpy>=0.9.1
 ecdsa<0.15
 py-bip39-bindings
 urllib3==1.26.15
-websocket>=0.2.1
-websocket-client==1.7.0
+websocket-client>=1.7.0


### PR DESCRIPTION
- remove websocket from requirements (websocket-client is enough)
- bump version

the fixed error:
```logs
AttributeError: module 'websocket' has no attribute 'WebSocketConnectionClosedException'
```